### PR TITLE
Rewrites parser buffer parsing logic. Fixes #6

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -63,7 +63,7 @@ fn handle_events(event_list: Vec<events::TelnetEvents>) -> CapturedEvents {
                 events.push(Event::SUBNEGOTIATION);
             }
             events::TelnetEvents::DataReceive(buffer) => {
-                println!("Receive: {:?}", buffer);
+                println!("Receive: {}", std::str::from_utf8(buffer.as_slice()).unwrap_or("Bad utf-8 bytes"));
                 events.push(Event::RECV);
             }
             events::TelnetEvents::DataSend(buffer) => {
@@ -84,6 +84,7 @@ fn test_parser() {
   }
   assert_eq!(handle_events(instance.receive(&[b"Hello, rust!", &[255, 249][..]].concat())), events![Event::RECV, Event::IAC]);
   assert_eq!(handle_events(instance.receive(&[255, 253, 201])), events![]);
+  assert_eq!(handle_events(instance.receive(&[&[255, 253, 200][..], b"Some random data"].concat())), events![Event::SEND, Event::RECV]);
   assert_eq!(handle_events(
     instance.receive(&events::TelnetSubnegotiation::new(201, b"Core.Hello {}").into_bytes()),
   ), events![Event::SUBNEGOTIATION]);


### PR DESCRIPTION
Fix for #6 

This is a pretty large re-write of the logic that extracts subvectors from Parser::buffer during Parser::process.
The solution uses a state machine and also avoids looking ahead in the buffer since this can cause index out of bound panics.

I made one assumption in the code that I'm not 100% on. I'll leave a reviewcomment on that particular line.
