### PR TITLE
Adds EOR to the telnet commands since it was missing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ impl Parser {
                 State::IAC => {
                     match val {
                         IAC => iter_state = State::Normal, // Double IAC, ignore
-                        GA | NOP => {
+                        GA | EOR | NOP => {
                             events.push(Vec::from(&self.buffer[cmd_begin..index+1]));
                             cmd_begin = index + 1;
                             iter_state = State::Normal;

--- a/src/telnet.rs
+++ b/src/telnet.rs
@@ -11,6 +11,7 @@ pub mod op_command {
   pub const IS: u8 = 0;
   pub const SEND: u8 = 1;
   pub const GA: u8 = 249;
+  pub const EOR: u8 = 239;
 }
 
 /// Module containing constants for Telnet Option codes.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,6 +91,9 @@ fn test_parser() {
   assert_eq!(handle_events(
     instance.receive(&[&events::TelnetSubnegotiation::new(201, b"Core.Hello {}").into_bytes()[..], b"Random text", &[255, 249][..]].concat()),
   ), events![Event::SUBNEGOTIATION, Event::RECV, Event::IAC]);
+  assert_eq!(handle_events(
+    instance.receive(&[87, 104, 97, 116, 32, 105, 115, 32, 121, 111, 117, 114, 32, 112, 97, 115, 115, 119, 111, 114, 100, 63, 32, 255, 239, 255, 251, 1])
+  ), events![Event::RECV, Event::IAC, Event::SEND]);
 }
 
 #[test]


### PR DESCRIPTION
The telnet option EOR exists but the actual command value doesn't. I just poked it in there because it will make my code look nicer if I can use it :smile: 