### PR TITLE
Adds Clone trait to CompatibilityTable

### DIFF
--- a/src/compatibility.rs
+++ b/src/compatibility.rs
@@ -49,6 +49,7 @@ impl CompatibilityEntry {
 }
 
 /// A table of options that are supported locally or remotely, and their current state.
+#[derive(Clone)]
 pub struct CompatibilityTable {
   options: [u8; 256],
 }


### PR DESCRIPTION
When instancing a new parser and want to keep support from an existing
one it's handy to be able to clone the compatibility table.
