### PR TITLE
Support no-std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,3 +17,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Build
+      run: cargo build --verbose --no-default-features
+    - name: Run tests
+      run: cargo test --verbose --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ exclude = ["docs/**", ".github/**"]
 
 [dependencies]
 bytes = "1.1.0"
+
+[features]
+default = ["std"]
+std = []

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,5 @@
 use crate::Parser;
+use alloc::vec::Vec;
 use bytes::{BufMut, Bytes, BytesMut};
 
 /// A struct representing a 2 byte IAC sequence.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,18 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+
 pub mod compatibility;
 pub mod events;
 pub mod telnet;
 
+use alloc::{format, vec::Vec};
 pub use bytes;
 
 use crate::telnet::op_command::*;
-
-#[cfg(test)]
-mod tests;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use compatibility::*;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,8 @@
-use crate::telnet::{op_command as cmd, op_option as opt};
-use crate::vbytes;
 use bytes::Bytes;
+use libtelnet_rs::telnet::{op_command as cmd, op_option as opt};
+use libtelnet_rs::vbytes;
 
-use super::*;
+use libtelnet_rs::*;
 
 /// Test the parser and its general functionality.
 


### PR DESCRIPTION
Adds "std" as a default feature. 

With "std" disabled it uses alloc for Vec<u8> and is no-std compatible.

Also moved tests into the "tests" directory which doesn't interfere with no-std during testing.