### PR TITLE
lib: fix extract_event_data State::Sub SE processing

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use bytes::{BufMut, Bytes, BytesMut};
 
 /// A struct representing a 2 byte IAC sequence.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TelnetIAC {
   pub command: u8,
 }
@@ -35,7 +35,7 @@ impl TelnetIAC {
 }
 
 /// A struct representing a 3 byte IAC sequence.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TelnetNegotiation {
   pub command: u8,
   pub option: u8,
@@ -69,7 +69,7 @@ impl TelnetNegotiation {
 }
 
 /// A struct representing an arbitrary length IAC subnegotiation sequence.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TelnetSubnegotiation {
   pub option: u8,
   pub buffer: Bytes,
@@ -106,7 +106,7 @@ impl TelnetSubnegotiation {
 }
 
 /// An enum representing various telnet events.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum TelnetEvents {
   /// An IAC command sequence.
   IAC(TelnetIAC),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -192,6 +192,45 @@ fn test_subneg_separate_receives() {
   assert_eq!(handle_events(events), events![Event::SUBNEGOTIATION]);
 }
 
+// Test that receiving a subnegotiation with embedded UTF-8 content works correctly,
+// even when the content includes a SE byte.
+#[test]
+fn test_subneg_utf8_content() {
+    use crate::events::TelnetEvents;
+    use cmd::{IAC, SB, SE};
+    use opt::GMCP;
+
+    // Create a parser that will support GMCP.
+    let mut parser = Parser::new();
+    parser.options.support_local(GMCP);
+    parser._will(GMCP);
+
+    // Construct a GMCP message containing a UTF-8 sequence that happens
+    // to include SE (0xF0). This should be permitted as long as the SE isn't
+    // preceeded by IAC (0xFF). For our test case we'll use the content
+    // '👋' (0xF0, 0x9F, 0x91, 0x8B) - where the leading byte is SE.
+    let prefix = &[IAC, SB, GMCP][..];
+    let wave_emoji = &[0xF0, 0x9F, 0x91, 0x8B][..];
+    let suffix = &[IAC, SE][..];
+    let gmcp_msg = [prefix, wave_emoji, suffix].concat();
+
+    // Receive the GMCP message with the parser. This should produce one event.
+    let events = parser.receive(&gmcp_msg);
+    assert_eq!(events.len(), 1, "only expected one event to be parsed");
+
+    // The event should be a Subnegotiation for the GMCP option, with the correct in-tact
+    // buffer contents.
+    if let TelnetEvents::Subnegotiation(sub) = events.get(0).unwrap() {
+        assert_eq!(sub.option, 201, "option should be GMCP");
+        assert_eq!(
+            sub.buffer, wave_emoji,
+            "buffer should be equal to the wave emoji"
+        );
+    } else {
+        panic!("missing expected DataReceive event");
+    }
+}
+
 #[test]
 fn test_concat() {
   let a: &[u8] = &[255, 102, 50, 65, 20];


### PR DESCRIPTION
## Description

* Impls `Debug` for `TelnetEvents` to make debugging/testing easiser.
* Changes `extract_event_data` to only emit `SubNegotiation` type event when in `State::Sub` and `IAC SE` is encountered in sequence, not just `SE`.

I happened to notice that UTF-8 emoji in Telnet subnegotiation GMCP data was causing strange behaviour in [Blightmud](https://github.com/Blightmud/Blightmud), a MUD client that uses `libtelnet-rs` for its Telnet processing. The effect was that GMCP messages containing certain emoji would be presented as unexpected Telnet events, truncate the emoji mid-byte, and deliver only part of the data to the MUD client. This led to corruption of prompt data and other strange effects. I wasn't able to reproduce this using [Mudlet](https://www.mudlet.org/), a separate MUD client with GMCP support, which led me to investigate the Telnet handling code.

Ultimately I was able to narrow the issue down to:
* Telnet subnegotiation messages (in this case, for GMCP)
* Containing UTF-8 encoded Emoji data
* Where the emoji in question had a leading 0xF0 byte.

The `libtelnet-rs` event processing logic was treating the 0xF0 of the subnegotiation payload as a telnet command terminating the subnegotiation, not as a byte of the payload data, because `0xF0` is the command code `SE` "End of subnegotiation parameters." in the context of telnet command processing. 

[RFC 854](https://www.rfc-editor.org/rfc/rfc854) says:
>  All TELNET commands consist of at least a two byte sequence:  the "Interpret as Command" (IAC) escape character followed by the code for the command.

In other words, seeing the `SE` command code on its own is not sufficient: it must be preceeded by the IAC escape character.

## Detailed Walkthrough

When extracting event data, if the parser is in the `State::Sub` state, it needs to look for the end of the sub-negotiation data to decide whether to push a `EventType::SubNegotiation` event.

Prior to this branch `extract_event_data` did so unconditionally upon encountering a `SE` value (0xF0) anytime after entering the `Sub` state. This incorrectly produces a `SubNegotiation` event type even if the `SE` value wasn't preceded by an `IAC` value (0xFF). This in turn leads to data being dropped, and the subnegotation data being turned into a truncated application data read.

For example, receiving the following data:

```
  [IAC, SB, GMCP, SE, 0x9F, 0x91, 0x8B, IAC, SE];
```

The `extract_event_data` fn would produce a `EventType::SubNegotiation` event type with the buf

```
  [IAC, SB, GMCP, SE]
```

and a `EventType::None` event type with the buf

```
  [0x9F, 0x91, 0x8b]
```

Later, in `process`, these two event types are processed.

First the `EventType::SubNegotiation` match arm will find the event buffer doesn't end with `IAC SE`, and so pushes the event buffer into its processing buffer, making `self.buffer` hold:

```
  [IAC, SB, GMCP, SE]
```

Processing continues to the next event, and the `EventType::None` match arm. This gets processed as a `TelnetEvents::DataReceive`, and the event buffer is passed as the application data.

We then reach the end of the events, and so the `self.buffer` content is cleared, and only the `TelnetEvents::DataReceive` event is returned, with the truncated data:

```
  [0x9F, 0x91, 0x8b]
```

The result _should_ be a `TelnetEvents::SubNegotiation` with `opt == GMCP` and `buffer == [SE, 0x9F, 0x91, 0x8B]`.

For that to happen `extract_event_data` needs to be changed to only emit the `SubNegotiation` event when it encounters the SE _after_ an IAC. This presents the entire subnegotiation event type buffer in tact to `process`, where it is turned into the expected `TelnetEvents::Subnegotiation` return.

This commit implements that fix, and adds a unit test matching the scenario described above.
