### PR TITLE
fix panic in subnegotiation handling, add fuzzing

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,24 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  fuzz:
+    name: Fuzz Testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install nightly rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+      - name: Fuzz TelnetParser receive
+        # Run the fuzzer for 60 seconds before giving up.
+        run: cargo fuzz run receive -- -max_total_time=60

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "libtelnet-rs-fuzz"
+version = "0.0.1"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
+
+[dependencies.libtelnet-rs]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "receive"
+path = "parser/receive.rs"
+test = false
+doc = false

--- a/fuzz/parser/receive.rs
+++ b/fuzz/parser/receive.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+use libfuzzer_sys::arbitrary;
+use libfuzzer_sys::arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use libtelnet_rs::compatibility::CompatibilityTable;
+use libtelnet_rs::Parser;
+
+#[derive(Arbitrary, Debug)]
+struct TelnetApplication {
+  options: Vec<(u8, u8)>,
+  received_data: Vec<Vec<u8>>,
+}
+
+fuzz_target!(|app: TelnetApplication| {
+  let mut parser = Parser::with_support(CompatibilityTable::from_options(&app.options));
+  for data in app.received_data {
+    parser.receive(&data);
+  }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl Parser {
           if buffer[len - 2] == IAC && buffer[len - 1] == SE {
             // Valid ending
             let opt = self.options.get_option(buffer[2]);
-            if opt.local && opt.local_state {
+            if opt.local && opt.local_state && len - 2 >= 3 {
               let dbuffer = vbytes!(&buffer[3..len - 2]);
               event_list.push(events::TelnetEvents::build_subnegotiation(
                 buffer[2], dbuffer,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,6 +3,7 @@ use libtelnet_rs::telnet::{op_command as cmd, op_option as opt};
 use libtelnet_rs::vbytes;
 
 use libtelnet_rs::*;
+use libtelnet_rs::compatibility::{CompatibilityEntry, CompatibilityTable};
 
 /// Test the parser and its general functionality.
 
@@ -216,4 +217,21 @@ fn test_unescape() {
   let a = vec![255, 255, 250, 201, 255, 255, 205, 202, 255, 255, 240];
   let expected = vbytes!(&[255, 250, 201, 255, 205, 202, 255, 240]);
   assert_eq!(expected, Parser::unescape_iac(a))
+}
+
+#[test]
+fn test_bad_subneg_dbuffer() {
+  // Configure opt 0xFF (IAC) as local supported, and local state enabled.
+  let entry = CompatibilityEntry::new(true, false, true, false);
+  let opts = CompatibilityTable::from_options(&[(
+    cmd::IAC,
+    entry.into_u8(),
+  )]);
+  // Receive a malformed subnegotiation - this should not panic.
+  Parser::with_support(opts).receive(&[
+    cmd::IAC,
+    cmd::SB,
+    cmd::IAC,
+    cmd::SE,
+  ]);
 }


### PR DESCRIPTION
## Description

This branch adds [cargo fuzz](https://github.com/rust-fuzz/cargo-fuzz) integration for the `TelnetParser::receive` code. This seemed like a prudent idea for a crate that parses untrusted network packets, and in fact, it found a panic very quickly. The panic is also fixed in this branch and a minimal unit test added.

I've also added a CI task that runs the fuzzer for 60s. This is sufficient for catching low hanging panics like the one described below (it was found within seconds of starting the fuzzer), and will help keep the fuzzer code from rotting over time. For proper fuzz testing it should be run longer. I've let the fuzzer run overnight on my machine and it didn't find any additional issues.

## Panic in subnegotiation handling

Iff the parser state decides `0xFF` is a locally supported and enabled enabled option, and a truncated subnegotiation for opt code `0xFF` is received, don't panic from a negative range end.

Previously in `TelnetParser::process(...)` when handling a `EventType::SubNegotiation` event buffer the processing code would look for a buffer ending in `IAC SE` and then try to pull out remaining data using a range expression like `&buffer[3..len - 2]`. If the buffer happens to be 4 bytes long, and the negotiated option was itself `0xFF`, and it ended with a single `SE` byte,  then the check for the proper ending will pass, thinking the option code is the `IAC` indicator for the `SE` command, when it's actually the option code. This will result in the range expression being `[3..2]` (since `len` is 4), which will panic.

The fix applied in this commit is to require that the buffer end in `IAC SE` _and_ that `len - 2` is greater or equal to 3. Note this bug is separate from https://github.com/envis10n/libtelnet-rs/pull/21 and must be fixed independently.

I believe the real world impact of this panic is quite low: a vulnerable application would have to be willing to negotiate support for  telnet option `0xFF` and I don't suspect any real world use cases would do this. None the less, we shouldn't panic for corner cases like this :-)
